### PR TITLE
mP1/walkingkooka-tree/pull/435 ExpressionNumberContext extends Decima…

### DIFF
--- a/src/main/java/walkingkooka/tree/patch/NodePatch.java
+++ b/src/main/java/walkingkooka/tree/patch/NodePatch.java
@@ -21,7 +21,7 @@ import walkingkooka.Cast;
 import walkingkooka.NeverError;
 import walkingkooka.naming.Name;
 import walkingkooka.tree.Node;
-import walkingkooka.tree.expression.ExpressionNumberContext;
+import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.json.JsonArray;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonObject;
@@ -35,6 +35,7 @@ import walkingkooka.tree.json.marshall.JsonNodeUnmarshallException;
 import walkingkooka.tree.pointer.NodePointer;
 import walkingkooka.tree.pointer.NodePointerException;
 
+import java.math.MathContext;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -177,14 +178,22 @@ public abstract class NodePatch<N extends Node<N, NAME, ?, ?>, NAME extends Name
     public static <N extends Node<N, NAME, ?, ?>, NAME extends Name> NodePatch<N, NAME> fromJsonPatch(final JsonNode node,
                                                                                                       final Function<String, NAME> nameFactory,
                                                                                                       final Function<JsonNode, N> valueFactory,
-                                                                                                      final ExpressionNumberContext context) {
+                                                                                                      final ExpressionNumberKind kind,
+                                                                                                      final MathContext context) {
         checkNode(node);
         Objects.requireNonNull(nameFactory, "nameFactory");
         Objects.requireNonNull(valueFactory, "valueFactory");
 
-        return Cast.to(unmarshall0(node,
-                NodePatchFromJsonFormat.jsonPatch(nameFactory, valueFactory),
-                JsonNodeUnmarshallContexts.basic(context)));
+        return Cast.to(
+                unmarshall0(
+                        node,
+                        NodePatchFromJsonFormat.jsonPatch(nameFactory, valueFactory),
+                        JsonNodeUnmarshallContexts.basic(
+                                kind,
+                                context
+                        )
+                )
+        );
     }
 
     /**

--- a/src/test/java/walkingkooka/tree/patch/NodePatchNonEmptyTestCase.java
+++ b/src/test/java/walkingkooka/tree/patch/NodePatchNonEmptyTestCase.java
@@ -124,10 +124,13 @@ public abstract class NodePatchNonEmptyTestCase<P extends NodePatchNonEmpty<Json
     }
 
     final NodePatch<JsonNode, JsonPropertyName> fromJsonPatch(final JsonNode node) {
-        return NodePatch.fromJsonPatch(node,
+        return NodePatch.fromJsonPatch(
+                node,
                 JsonPropertyName::with,
                 Function.identity(),
-                ExpressionNumberContexts.basic(ExpressionNumberKind.DEFAULT, MathContext.DECIMAL32));
+                ExpressionNumberKind.DEFAULT,
+                MathContext.DECIMAL32
+        );
     }
 
     final void toJsonPatchAndCheck2(final NodePatch<JsonNode, JsonPropertyName> patch,

--- a/src/test/java/walkingkooka/tree/patch/NodePatchTest.java
+++ b/src/test/java/walkingkooka/tree/patch/NodePatchTest.java
@@ -22,35 +22,88 @@ import walkingkooka.Cast;
 import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.tree.expression.ExpressionNumberContext;
 import walkingkooka.tree.expression.ExpressionNumberContexts;
+import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonPropertyName;
 
+import java.math.MathContext;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public final class NodePatchTest extends NodePatchTestCase2<NodePatch<JsonNode, JsonPropertyName>> {
-    
-    private final static ExpressionNumberContext CONTEXT = ExpressionNumberContexts.fake();
+
+    private final static ExpressionNumberKind KIND = ExpressionNumberKind.DEFAULT;
+    private final static MathContext CONTEXT = MathContext.DECIMAL32;
 
     @Test
     public void testFromJsonPatchNullJsonNodeFails() {
-        assertThrows(NullPointerException.class, () -> NodePatch.fromJsonPatch(null, this.nameFactory(), this.valueFactory(), CONTEXT));
+        assertThrows(
+                NullPointerException.class,
+                () -> NodePatch.fromJsonPatch(
+                        null,
+                        this.nameFactory(),
+                        this.valueFactory(),
+                        KIND,
+                        CONTEXT
+                )
+        );
     }
 
     @Test
     public void testFromJsonPatchNullNameFactoryFails() {
-        assertThrows(NullPointerException.class, () -> NodePatch.fromJsonPatch(JsonNode.object(), null, this.valueFactory(), CONTEXT));
+        assertThrows(
+                NullPointerException.class,
+                () -> NodePatch.fromJsonPatch(
+                        JsonNode.object(),
+                        null,
+                        this.valueFactory(),
+                        KIND,
+                        CONTEXT
+                )
+        );
     }
 
     @Test
     public void testFromJsonPatchNullValueFactoryFails() {
-        assertThrows(NullPointerException.class, () -> NodePatch.fromJsonPatch(JsonNode.object(), this.nameFactory(), null, CONTEXT));
+        assertThrows(
+                NullPointerException.class,
+                () -> NodePatch.fromJsonPatch(
+                        JsonNode.object(),
+                        this.nameFactory(),
+                        null,
+                        KIND,
+                        CONTEXT
+                )
+        );
     }
 
     @Test
-    public void testFromJsonPatchNullExpressionNumberContextFails() {
-        assertThrows(NullPointerException.class, () -> NodePatch.fromJsonPatch(JsonNode.object(), this.nameFactory(), this.valueFactory(), null));
+    public void testFromJsonPatchNullKindFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> NodePatch.fromJsonPatch(
+                        JsonNode.object(),
+                        this.nameFactory(),
+                        this.valueFactory(),
+                        null,
+                        CONTEXT
+                )
+        );
+    }
+
+    @Test
+    public void testFromJsonPatchNullMathContextFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> NodePatch.fromJsonPatch(
+                        JsonNode.object(),
+                        this.nameFactory(),
+                        this.valueFactory(),
+                        KIND,
+                        null
+                )
+        );
     }
     
     private Function<String, JsonPropertyName> nameFactory() {


### PR DESCRIPTION
…lNumberContext

- NodePatch.fromJsonPatch replaced ExpressionNumberContext with ExpressionNumberKind & MathContext.

- https://github.com/mP1/walkingkooka-tree/pull/435
- ExpressionNumberContext extends DecimalNumberContext